### PR TITLE
Display and update extra data

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ And visit [http://localhost:9292/](http://localhost:9292/).
 Alternatively you can also configure which Redis with:
 
 ```sh
-REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 be rerun rackup
+REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 bundle exec rerun rackup
 ```
 
 ## License

--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -58,6 +58,22 @@ form.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm action=feature_path(@fea
       )
         = @feature.users.join(', ')
 
+  .mb-5
+    label.block.text-gray-500.mb-2 Additional Data
+
+    dl
+    - @feature.data.each do |name, val|
+      - next if name == 'description'
+      .sm:grid.sm:grid-cols-3.sm:gap-4.sm:px-6
+        dd.text-sm.leading-5.font-medium.text-gray-500 = name
+        input.appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-white.mt-1.sm:mt-0.sm:col-span-2(
+         name=name
+         id=name
+         value=(val == true ? 'true' : (val == false ? 'false' : val))
+         class='hover:border-gray-500'
+       )
+       
+      
   .flex.items-center.justify-end
     form action=delete_feature_path(@feature.name) method='POST'
       button.mr-5.text-gray-600(class='hover:underline' type='submit' onclick="return confirm('Are you sure you want to delete #{@feature.name}?')")

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -45,7 +45,20 @@ module Rollout::UI
           if params[:users]
             feature.users = params[:users].split(',').map(&:strip).uniq.sort
           end
-          feature.data.update(description: params[:description])
+          feature.data.each do |name, old_val|
+            new_val = params[name]
+
+            # keep type the same (for integers/boolean/strings)
+            new_val = if old_val.is_a? Integer
+              new_val.to_i
+            elsif !!old_val == old_val
+              new_val == 'true' ? true : (new_val == 'false' ? false : !!new_val)
+            else
+              new_val
+            end
+
+            feature.data.update(name => new_val)
+          end
         end
       end
 

--- a/rollout-ui.gemspec
+++ b/rollout-ui.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'sinatra', '~> 2.0'
   spec.add_dependency 'slim', '~> 4.0'
 
-  spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rerun', '~> 0.13'


### PR DESCRIPTION
rollup allows storing arbitrary extra data attributes. from the readme:

```
$rollout.set_feature_data(:chat, description: 'foo', release_date: 'bar', whatever: 'baz')
```

however, rollout-ui does not display the extra data (in this case, `:release_data` and `:whatever`) or allow updating it. in this PR, we enable both. it looks like this:

![image](https://user-images.githubusercontent.com/200575/94768884-83a2d900-0365-11eb-97cb-50b3bd612b4d.png)

when updating, we try to keep the type of extra data the same -- if it was an integer, it will remain an integer, if it was a boolean, it will remain a boolean, and otherwise it will be a string.
