### PR TITLE
Fix no-wrap on rollout feature description

### DIFF
--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -24,7 +24,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
       - @features.each do |feature_name|
         - feature = @rollout.get(feature_name)
         tr.border-b.border-gray-200
-          td.py-2.whitespace-no-wrap
+          td.py-2
             a.text-blue-600(href=feature_path(feature.name) class='hover:text-blue-700 hover:underline')
               = feature_name
             div.text-gray-500.text-xs = feature.data['description']


### PR DESCRIPTION
feature description might be long, but this column is currently set as a `whitespace-no-wrap` which cause all there others column to be moved out of the screen..

<img width="1791" alt="Fullscreen_1_4_21__14_21" src="https://user-images.githubusercontent.com/1517759/103539440-5e5bc480-4e98-11eb-8af2-2d9fbc69de7f.png">

vs

<img width="1408" alt="Fullscreen_1_4_21__14_23" src="https://user-images.githubusercontent.com/1517759/103539510-83e8ce00-4e98-11eb-97b4-27f360b0dc7c.png">
