### PR TITLE
Fix specs, with more idiomatic use of RSpec matchers

### DIFF
--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
+
 ENV['APP_ENV'] = 'test'
-RSpec.describe 'Web UIp' do
+
+RSpec.describe 'Web UI' do
   include Rack::Test::Methods
 
   def app
@@ -9,16 +11,19 @@ RSpec.describe 'Web UIp' do
 
   it "renders index html" do
     get '/'
-    expect(last_response.body.include?('Rollout UI'))
-    expect(last_response.status == 200)
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('Rollout UI')
   end
 
   it "renders index json" do
     ROLLOUT.activate(:fake_test_feature_for_rollout_ui_webspec)
     header 'Accept', 'application/json'
+
     get '/'
-    expect(last_response.status == 200)
-    expect(last_response.headers['Content-Type'] == 'application/json')
+
+    expect(last_response).to be_ok
+    expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)
     expected_response = {
       "data"=>{},
@@ -26,7 +31,7 @@ RSpec.describe 'Web UIp' do
       "name"=>"fake_test_feature_for_rollout_ui_webspec",
       "percentage"=>100.0
     }
-    expect(response).to(include(expected_response))
+    expect(response).to include(expected_response)
     ROLLOUT.delete(:fake_test_feature_for_rollout_ui_webspec)
   end
 
@@ -37,10 +42,10 @@ RSpec.describe 'Web UIp' do
 
     header 'Accept', 'application/json'
     get '/?user=different_user'
-    expect(last_response.status == 200)
-    expect(last_response.headers['Content-Type'] == 'application/json')
+    expect(last_response).to be_ok
+    expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)
-    expect(response == [])
+    expect(response).to be_empty
 
     expected_feature = {
       "data" => {},
@@ -50,17 +55,17 @@ RSpec.describe 'Web UIp' do
     }
     header 'Accept', 'application/json'
     get '/?user=fake_user'
-    expect(last_response.status == 200)
-    expect(last_response.headers['Content-Type'] == 'application/json')
+    expect(last_response).to be_ok
+    expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)
-    expect(response).to(include(expected_feature))
+    expect(response).to include(expected_feature)
 
     header 'Accept', 'application/json'
     get '/?group=fake_group'
-    expect(last_response.status == 200)
-    expect(last_response.headers['Content-Type'] == 'application/json')
+    expect(last_response).to be_ok
+    expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)
-    expect(response).to(include(expected_feature))
+    expect(response).to include(expected_feature)
 
     ROLLOUT.deactivate_user(:fake_test_feature_for_rollout_ui_webspec, 'fake_user')
     ROLLOUT.deactivate_group(:fake_test_feature_for_rollout_ui_webspec, :fake_group)
@@ -69,17 +74,19 @@ RSpec.describe 'Web UIp' do
 
   it "renders show html" do
     get '/features/test'
-    expect(last_response.body.include?('Rollout UI'))
-    expect(last_response.body.include?('test'))
-    expect(last_response.status == 200)
+
+    expect(last_response).to be_ok
+    expect(last_response.body).to include('Rollout UI') & include('test')
   end
 
   it "renders show json" do
     ROLLOUT.activate(:fake_test_feature_for_rollout_ui_webspec)
     header 'Accept', 'application/json'
+ 
     get '/features/fake_test_feature_for_rollout_ui_webspec'
-    expect(last_response.status == 200)
-    expect(last_response.headers['Content-Type'] == 'application/json')
+ 
+    expect(last_response).to be_ok
+    expect(last_response.headers).to include('Content-Type' => 'application/json')
     response = JSON.parse(last_response.body)
     expected_response = {
       "data"=>{},
@@ -87,7 +94,8 @@ RSpec.describe 'Web UIp' do
       "name"=>"fake_test_feature_for_rollout_ui_webspec",
       "percentage"=>100.0
     }
-    expect(expected_response == response)
+    expect(expected_response).to eq response
+
     ROLLOUT.delete(:fake_test_feature_for_rollout_ui_webspec)
   end
 end


### PR DESCRIPTION
I noticed many of the checks in the specs use `expect(some_boolean_condition)`, e.g. `expect(last_response.status == 200)`, which does not have the "expected" effect. This creates an expectation object on the boolean (whether true or false) but then doesn't run any matcher against it.

For example, in the `"renders show json"` spec, if you change `expect(last_response.status == 200)` to `expect(last_response.status == 123)`, the spec still passes. Adding a matcher makes it (correctly) fail: `expect(last_response.status == 123).to be true`
→
```
Failures:

  1) Web UIp renders show json
     Failure/Error: expect(expected_response == response).to be true
     
       expected true
            got false
```

The specs could make better use of [RSpec's matchers](https://www.rubydoc.info/gems/rspec-expectations/RSpec/Matchers), rather than the boolean assertion style shown above. The matchers can provide more details when a spec fails.
e.g. with `expect(last_response.status).to eq 123` the failure shows the expected vs actual value rather than just "the test failed":
```
Failures:

  1) Web UIp renders show json
     Failure/Error: expect(last_response.status).to eq 123
     
       expected: 123
            got: 200
     
       (compared using ==)
```

This could also be expressed at a higher level, checking the response's `ok?` predicate via the `be_ok` matcher: `expect(last_response).to be_ok`.

As another example, again in the `"renders show json"` spec, if you change the `expected_response` to:
```ruby
    expected_response = {
      ...
      "name"=>"wrong name",
      "percentage"=>50.0
    }
```
the spec still passes, for the same reason as above: there's an expect, `expect(expected_response == response)`, but no matcher. If changed to `expect(expected_response).to eq response` then it fails as follows, nicely showing the field-level diff as well:
```ruby
  1) Web UIp renders show json
     Failure/Error: expect(expected_response).to eq response
     
       expected: {"data"=>{}, "groups"=>[], "name"=>"fake_test_feature_for_rollout_ui_webspec", "percentage"=>100.0}
            got: {"data"=>{}, "groups"=>[], "name"=>"wrong name", "percentage"=>50.0}
     
       (compared using ==)
     
       Diff:
       @@ -1,5 +1,5 @@
        "data" => {},
        "groups" => [],
       -"name" => "fake_test_feature_for_rollout_ui_webspec",
       -"percentage" => 100.0,
       +"name" => "wrong name",
       +"percentage" => 50.0,
```

The changes here fix up the `expect`s, preferring higher level, more expressive matchers as appropriate.