### PR TITLE
Fix when using rollout-ui with Rack >= 3.1.0

### DIFF
--- a/lib/rollout/ui/helpers.rb
+++ b/lib/rollout/ui/helpers.rb
@@ -110,7 +110,7 @@ module Rollout::UI
     end
 
     def sanitized_name(feature_name)
-      Rack::Utils.escape_html(feature_name)
+      Rack::Utils.escape_html(feature_name.to_s)
     end
   end
 end


### PR DESCRIPTION
The latest version of Rack, 3.1.0, has introduced [this change](https://github.com/rack/rack/pull/2099) which requires calling `Rack::Utils.escape_html` explicitly with a string.

```
2024-06-11T11:52:53.030913+00:00 app[web.1]: I, [2024-06-11T11:52:53.030769 #23]  INFO -- : Started GET "/rollout" for 162.158.38.196 at 2024-06-11 11:52:53 +0000
2024-06-11T11:52:53.175028+00:00 app[web.1]: 2024-06-11 11:52:53 - TypeError - no implicit conversion of Symbol into String:
2024-06-11T11:52:53.175030+00:00 app[web.1]:
2024-06-11T11:52:53.175030+00:00 app[web.1]: Rack::Utils.escape_html(feature_name)
2024-06-11T11:52:53.175031+00:00 app[web.1]: ^^^^^^^^^^^^
```

So, this PR updates the `#sanitized_name` method to make sure that the feature name is converted to a string before sanitizing.

