### PR TITLE
Improve history UI + propose a release of v0.7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/vendor/
 
 # rspec failure tracking
 .rspec_status

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ And visit [http://localhost:9292/](http://localhost:9292/).
 Alternatively you can also configure which Redis with:
 
 ```sh
-REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 be rerun rackup
+REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 bundle exec rerun rackup
 ```
 
 ## License

--- a/lib/rollout/ui/config.rb
+++ b/lib/rollout/ui/config.rb
@@ -9,7 +9,12 @@ module Rollout::UI
       instance
       actor
       actor_url
+      timestamp_format
     ].freeze
+
+    DEFAULT_VALUES = {
+      timestamp_format: '%Y-%m-%d %H:%M %Z'
+    }.freeze
 
     KEYS.each do |key|
       define_method(key) do |&block|
@@ -17,6 +22,8 @@ module Rollout::UI
 
         if block
           @blocks[key] = block
+        elsif DEFAULT_VALUES.key?(key)
+          DEFAULT_VALUES[key]
         else
           raise ArgumentError, "#{key}: block is required"
         end
@@ -29,7 +36,10 @@ module Rollout::UI
       @blocks ||= {}
       block = @blocks[key]
 
-      return if block.nil?
+      if block.nil?
+        return DEFAULT_VALUES[key] if DEFAULT_VALUES.key?(key)
+        return nil
+      end
 
       if scope
         scope.instance_eval(&block)
@@ -39,7 +49,7 @@ module Rollout::UI
     end
 
     def defined?(key)
-      !@blocks.nil? && @blocks.key?(key)
+      (@blocks&.key?(key)) || DEFAULT_VALUES.key?(key)
     end
   end
 end

--- a/lib/rollout/ui/version.rb
+++ b/lib/rollout/ui/version.rb
@@ -1,5 +1,5 @@
 class Rollout
   module UI
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end

--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -42,7 +42,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               = feature.users.count
           - if @rollout.respond_to?(:logging)
             td.py-2.whitespace-no-wrap
-              span title=@rollout.logging.updated_at(feature_name).strftime('%Y-%m-%d %H:%M %Z') = time_ago(@rollout.logging.updated_at(feature_name))
+              span title=@rollout.logging.updated_at(feature_name).strftime(Rollout::UI.config.timestamp_format) = time_ago(@rollout.logging.updated_at(feature_name))
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")

--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -42,7 +42,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               = feature.users.count
           - if @rollout.respond_to?(:logging)
             td.py-2.whitespace-no-wrap
-              = time_ago(@rollout.logging.updated_at(feature_name))
+              span title=@rollout.logging.updated_at(feature_name).strftime('%Y-%m-%d %H:%M %Z') = time_ago(@rollout.logging.updated_at(feature_name))
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")

--- a/lib/rollout/ui/views/features/partials/event_log.slim
+++ b/lib/rollout/ui/views/features/partials/event_log.slim
@@ -43,4 +43,4 @@
                 = event.data
 
             td.py-2.text-right.whitespace-nowrap.pl-3.w-1/6
-              span title=event.created_at.strftime('%Y-%m-%d %H:%M %Z') = time_ago(event.created_at)
+              span title=event.created_at.strftime(Rollout::UI.config.timestamp_format) = time_ago(event.created_at)

--- a/lib/rollout/ui/views/features/partials/event_log.slim
+++ b/lib/rollout/ui/views/features/partials/event_log.slim
@@ -7,22 +7,22 @@
   .w-8.h-1.bg-gray-300.my-10
 
   .overflow-auto.scrolling-touch
-    table.text-sm.w-100.text-left.w-full
+    table.text-sm.w-100.text-left.w-full.table-fixed
       - if show_header
         thead.font-semibold.text-gray-600.border-b.border-gray-200
           - if show_feature
-            th.pb-2.pr-3 Feature
-          th.pb-2.pr-3 Action
-          th.pl-2
+            th.pb-2.pr-3.w-1/6 Feature
+          th.pb-2.pr-3.w-2/3 Action
+          th.pl-2.w-1/6
 
       tbody.text-gray-600.border-t.border-gray-200
         - events.each do |event|
           tr.border-b.border-gray-200
             - if show_feature
-              td.py-2.whitespace-no-wrap
+              td.py-2.whitespace-no-wrap.w-1/6
                 a.text-blue-600(href=feature_path(event.feature) class='hover:text-blue-700 hover:underline')
                   = event.feature
-            td.py-2.pr-3.whitespace-no-wrap
+            td.py-2.pr-3.whitespace-normal.w-2/3
               - if event.name == "update"
                 - if event.context && event.context[:actor]
                   - if config.defined?(:actor_url)
@@ -42,5 +42,5 @@
               - else
                 = event.data
 
-            td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
+            td.py-2.text-right.whitespace-nowrap.pl-3.w-1/6
               = time_ago(event.created_at)

--- a/lib/rollout/ui/views/features/partials/event_log.slim
+++ b/lib/rollout/ui/views/features/partials/event_log.slim
@@ -32,7 +32,7 @@
                     ' #{event.context[:actor]}
                 - else
                   ' unidentified user
-                - changes = event.data.fetch(:before).keys.map do |key|
+                - changes = event.data.fetch(:before).keys.reject { |key| key.to_s == 'data.updated_at' }.map do |key|
                   - before = format_change_value(event.data.fetch(:before).fetch(key))
                   - after = format_change_value(event.data.fetch(:after).fetch(key))
                   - "#{format_change_key(key)} from #{before} to #{after}"
@@ -43,4 +43,4 @@
                 = event.data
 
             td.py-2.text-right.whitespace-nowrap.pl-3.w-1/6
-              = time_ago(event.created_at)
+              span title=event.created_at.strftime('%Y-%m-%d %H:%M %Z') = time_ago(event.created_at)

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe 'Web UI' do
   include Rack::Test::Methods
 
   def app
-    Rollout::UI::Web
+    Rollout::UI::Web.tap do |app|
+      app.set :host_authorization, skip: true
+    end
   end
 
   it "renders index html" do

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe 'Web UI' do
     get '/'
 
     expect(last_response).to be_ok
-    expect(last_response.body).to include('Rollout UI') & include("&amp;lt;script&amp;gt;alert(1)&amp;lt;&amp;")
+    expect(last_response.body).to include('Rollout UI') & (include("&amp;lt;script&amp;gt;alert(1)&amp;lt;&amp;") | include('&lt;script&gt;alert(1)&lt;/script&gt;'))
   end
 
   it "renders show html" do
@@ -94,7 +94,7 @@ RSpec.describe 'Web UI' do
     get "/features/'+alert(1)+'"
 
     expect(last_response).to be_ok
-    expect(last_response.body).to include('Rollout UI') & include("&amp;#x27;+alert(1)+&amp;#x27;")
+    expect(last_response.body).to include('Rollout UI') & (include("&amp;#x27;+alert(1)+&amp;#x27;") | include("&#39;+alert(1)+&#39;"))
   end
 
   it "renders show json" do


### PR DESCRIPTION
A set of improvements to make the app more convenient to use in some real-world use cases. 😛

* get rid of horizontal scrolling when you have long actions in the History,
* get rid of redundant strings like `updated_at from '' to 1742638590` in the Actions column of History - this is the same as the timestamp in the right column,
* add absolute timestamps as tooltips for the relative ones,

...and some minor tweaks and updates, among others to make the tests pass.