### PR TITLE
fill summary and description in gemspec.

### DIFF
--- a/rollout-ui.gemspec
+++ b/rollout-ui.gemspec
@@ -8,8 +8,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['FetLife']
   spec.email         = ['dev@fetlife.com']
 
-  spec.summary       = %q{}
-  spec.description   = %q{}
+  spec.summary       = %q{Minimalist web ui for the rollout gem}
+  spec.description   = %q{Rack-mountable app to use and configure feature flags via the rollout gem}
   spec.homepage      = 'https://github.com/fetlife/rollout-ui'
   spec.license       = 'MIT'
 


### PR DESCRIPTION
The info is displayed and searchable via rubygems, e.g. on the web https://rubygems.org/search?query=rollout-ui , https://rubygems.org/gems/rollout-ui .