### PR TITLE
Handle `updated_at` being nil

### DIFF
--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -43,10 +43,10 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
           - if @rollout.respond_to?(:logging)
             td.py-2.whitespace-no-wrap
               - updated_at = @rollout.logging.updated_at(feature_name)
-              - if updated_at.present?
-                span title=updated_at.strftime(Rollout::UI.config.timestamp_format) = time_ago(updated_at)
-              - else
+              - if updated_at.nil?
                 span.text-gray-400 Never
+              - else
+                span title=updated_at.strftime(Rollout::UI.config.timestamp_format) = time_ago(updated_at)
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")

--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -42,7 +42,11 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
               = feature.users.count
           - if @rollout.respond_to?(:logging)
             td.py-2.whitespace-no-wrap
-              span title=@rollout.logging.updated_at(feature_name).strftime(Rollout::UI.config.timestamp_format) = time_ago(@rollout.logging.updated_at(feature_name))
+              - updated_at = @rollout.logging.updated_at(feature_name)
+              - if updated_at.present?
+                span title=updated_at.strftime(Rollout::UI.config.timestamp_format) = time_ago(updated_at)
+              - else
+                span.text-gray-400 Never
           td.flex.items-center.py-2.justify-end.whitespace-no-wrap.pl-3
             form action=activate_percentage_feature_path(feature_name, 100) method='POST'
               button.p-3.bg-gray-100.ml-1.rounded-sm.font-bold.leading-none.transition-colors.duration-150(class='hover:bg-gray-200' type='submit' onclick="return confirm('Are you sure you want activate #{sanitized_name(feature_name)} to 100%?')")


### PR DESCRIPTION
Prevent an exception when `logging.updated_at` is nil.

Possible causes:
 - Enabling the logging module for the first time
 - Upgrading to logging support
 - Bad seed data


<img width="1259" height="106" alt="Screenshot 2025-08-04 at 16 46 36" src="https://github.com/user-attachments/assets/90398984-a793-46e1-8c47-a41f99e31abc" />
