### PR TITLE
Automated Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec spec 
+      - name: Release to RubyGems
+        run: bundle exec rake release
+        env:
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run tests
         run: bundle exec spec 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,15 @@ jobs:
           bundler-cache: true
       - name: Run tests
         run: bundle exec spec 
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false 
       - name: Release to RubyGems
         run: bundle exec rake release
         env:
-          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }} 
+          RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec spec 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ end
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/fetlife/rollout-ui.
 
+### Development
+
 To run this project for development in isolation:
 
 ```sh
@@ -106,6 +108,14 @@ Alternatively you can also configure which Redis with:
 ```sh
 REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 bundle exec rerun rackup
 ```
+
+### Releasing
+
+1. Bump version: `rake version:patch` (or `minor`/`major`)
+2. Commit and tag: `git commit -am "Bump version" && git tag v0.7.3`
+3. Push: `git push origin main --tags`
+
+The GitHub Actions workflow will automatically publish to RubyGems when tags are pushed.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ REDIS_HOST=localhost REDIS_PORT=6379 REDIS_DB=10 bundle exec rerun rackup
 
 1. Bump version: `rake version:patch` (or `minor`/`major`)
 2. Commit and tag: `git commit -am "Bump version" && git tag v0.7.3`
-3. Push: `git push origin main --tags`
+3. Push: `git push origin master --tags`
 
 The GitHub Actions workflow will automatically publish to RubyGems when tags are pushed.
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,45 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+namespace :version do
+  desc "Bump patch version"
+  task :patch do
+    bump_version(:patch)
+  end
+  
+  desc "Bump minor version"
+  task :minor do
+    bump_version(:minor)
+  end
+  
+  desc "Bump major version"
+  task :major do
+    bump_version(:major)
+  end
+end
+
+def bump_version(type)
+  require 'rollout/ui/version'
+  current_version = Rollout::UI::VERSION
+  major, minor, patch = current_version.split('.').map(&:to_i)
+  
+  new_version = case type
+  when :major
+    "#{major + 1}.0.0"
+  when :minor
+    "#{major}.#{minor + 1}.0"
+  when :patch
+    "#{major}.#{minor}.#{patch + 1}"
+  end
+  
+  puts "Bumping version from #{current_version} to #{new_version}"
+  
+  # Update version file
+  version_file = 'lib/rollout/ui/version.rb'
+  content = File.read(version_file)
+  updated_content = content.gsub(/VERSION\s*=\s*"[^"]+"/, "VERSION = \"#{new_version}\"")
+  File.write(version_file, updated_content)
+  
+  puts "Version bumped to #{new_version}"
+end


### PR DESCRIPTION
The RubyGems and GitHub Releases are sometimes out of sync or manually overlooked.  
This PR adds an automated release workflow that triggers whenever a tag is pushed to `master`.

### What this does
- Automatically creates a GitHub Release
- Publishes the gem to RubyGems without manual steps

### Why
This keeps releases consistent across platforms and removes the risk of missed or delayed deployments.