### PR TITLE
Fix dark theme: add missing overrides for form elements

### DIFF
--- a/lib/rollout/ui/views/layout.slim
+++ b/lib/rollout/ui/views/layout.slim
@@ -21,6 +21,9 @@ html
       | .dark .hover\:bg-gray-200:hover { background-color: #3a3a3a; }
       | .dark .text-blue-600 { color: #60a5fa; }
       | .dark .hover\:text-blue-700:hover { color: #93c5fd; }
+      | .dark .bg-white { background-color: #333333; }
+      | .dark .border-gray-300 { border-color: #555555; }
+      | .dark .hover\:bg-gray-800:hover { background-color: #4a4a4a; }
 
   body
     / Addresses https://stackoverflow.com/questions/21147149/flash-of-unstyled-content-fouc-in-firefox-only-is-ff-slow-renderer


### PR DESCRIPTION
Form inputs, textareas, and select dropdowns used `bg-white` and `border-gray-300` which had no dark mode overrides, causing them to render with a bright white background in dark mode. Also adds an override for `hover:bg-gray-800` on submit buttons so the hover state doesn't go overly dark.

The dark mode implementation (added in 42d4864) works by applying CSS overrides under the .dark class in layout.slim. It covered the most common Tailwind gray utilities (bg-gray-100/200/300, text-gray-400–700, border-gray-200), but missed three classes that are used specifically on form elements:

1.  `bg-white` — Used on all `<input>`, `<textarea>`, and `<select>` elements in the New Feature and Edit Feature forms. Without an override, these render with a bright white background in dark mode, making them stand out harshly against the dark `#1a1a1a` page background. Fixed to `#333333`, which matches the existing `bg-gray-200` dark value and nests correctly inside the `bg-gray-100` form container (`#2a2a2a`).
2.  `Border-gray-300` — Used as the border on the groups `<select> `dropdown. Without an override it stays at Tailwind's default mid-gray, which has poor contrast on a dark background. Fixed to `#555555`, slightly lighter than the `border-gray-200` dark value (`#404040`) to preserve the visual hierarchy between the two border weights.
3. `Hover:bg-gray-800:hover` — Used as the hover state on the Create/Update submit buttons. In light mode this darkens the button on hover (`gray-700` → `gray-800`), which is a natural interaction cue. In dark mode, `bg-gray-800` (`#1f2937`) would make the button nearly black and lose contrast against the dark page. Fixed to `#4a4a4a` so the hover still provides a visible lightening effect in dark context.

https://claude.ai/code/session_01JkEFGGzfsF3rBEkb91Lsfz