### PR TITLE
Fix dark mode border color on bare .border inputs and textareas

### DIFF
--- a/lib/rollout/ui/version.rb
+++ b/lib/rollout/ui/version.rb
@@ -1,5 +1,5 @@
 class Rollout
   module UI
-    VERSION = "0.8.0"
+    VERSION = "0.8.1"
   end
 end

--- a/lib/rollout/ui/views/layout.slim
+++ b/lib/rollout/ui/views/layout.slim
@@ -17,6 +17,7 @@ html
       | .dark .bg-gray-100 { background-color: #2a2a2a; }
       | .dark .bg-gray-200 { background-color: #333333; }
       | .dark .bg-gray-300 { background-color: #404040; }
+      | .dark .border { border-color: #555555; }
       | .dark .border-gray-200 { border-color: #404040; }
       | .dark .hover\:bg-gray-200:hover { background-color: #3a3a3a; }
       | .dark .text-blue-600 { color: #60a5fa; }


### PR DESCRIPTION
Form inputs and textareas use Tailwind's bare .border class (no explicit border-gray-* class), so they kept the light-mode default (#e5e7eb) in dark mode. Adding .dark .border before the specific border-gray-* rules gives all bordered elements #555555 (matching the multi-select), while elements with .border-gray-200 are still overridden to #404040 by the subsequent rule.

https://claude.ai/code/session_01JkEFGGzfsF3rBEkb91Lsfz