### PR TITLE
Convert to plain Rack app to remove sinatra and sinatra-contrib dependencies

### DIFF
--- a/lib/rollout/ui.rb
+++ b/lib/rollout/ui.rb
@@ -1,4 +1,3 @@
-require "sinatra"
 require "rollout"
 
 require "rollout/ui/version"

--- a/lib/rollout/ui/config.rb
+++ b/lib/rollout/ui/config.rb
@@ -1,4 +1,3 @@
-require "sinatra"
 require "rollout"
 
 require "rollout/ui/version"

--- a/lib/rollout/ui/helpers.rb
+++ b/lib/rollout/ui/helpers.rb
@@ -1,4 +1,4 @@
-require "sinatra"
+require "rack"
 require "rollout"
 
 require "rollout/ui/version"

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -11,7 +11,7 @@ module Rollout::UI
   class Web
     PUBLIC_PATH = File.expand_path('public', __dir__)
 
-    NOT_FOUND = ->(env) { [404, { 'content-type' => 'text/plain' }, ['Not Found']] }
+    NOT_FOUND = ->(env) { [404, { 'content-type' => 'text/plain', 'x-cascade' => 'pass' }, ['Not Found']] }
 
     def initialize
       @static = Rack::Static.new(NOT_FOUND, urls: ['/css'], root: PUBLIC_PATH)
@@ -48,14 +48,29 @@ module Rollout::UI
       def call(env)
         @request = Rack::Request.new(env)
         @response = Rack::Response.new
+        response['x-content-type-options'] = 'nosniff'
+        response['x-frame-options'] = 'SAMEORIGIN'
+        response['x-xss-protection'] = '1; mode=block'
 
-        route = ROUTES.find { |verb, pattern, _| verb == request.request_method.to_sym && pattern.match?(request.path_info) }
+        # Rack::URLMap strips the mount prefix from PATH_INFO, leaving "" (not
+        # "/") when a mounted app is requested at its exact mount point.
+        path_info = request.path_info
+        path_info = '/' if path_info.empty?
+
+        method = request.request_method.to_sym
+        lookup_method = method == :HEAD ? :GET : method
+        route = ROUTES.find { |verb, pattern, _| verb == lookup_method && pattern.match?(path_info) }
         return not_found unless route
 
         _, pattern, action = route
-        @params = build_params(pattern.match(request.path_info).named_captures)
+        begin
+          @params = build_params(pattern.match(path_info).named_captures)
+        rescue Rack::BadRequest => e
+          return bad_request(e)
+        end
 
         send(action)
+        response.body = [] if method == :HEAD
         response.finish
       end
 
@@ -141,24 +156,53 @@ module Rollout::UI
       def not_found
         response.status = 404
         response['content-type'] = 'text/plain'
+        response['x-cascade'] = 'pass'
         response.write('Not Found')
         response.finish
       end
 
+      def bad_request(error)
+        response.status = 400
+        response['content-type'] = 'text/plain'
+        response.write("Bad Request: #{error.message}")
+        response.finish
+      end
+
       def build_params(route_params)
+        route_params = route_params.transform_values { |value| Rack::Utils.unescape_path(value) }
+
         request.params.merge(route_params).each_with_object({}) do |(key, value), hash|
           hash[key.to_s] = value
           hash[key.to_sym] = value
         end
       end
 
+      # Mirrors Sinatra's own `redirect`: browsers replaying a 302 after a
+      # non-GET request may re-issue the original method, so redirects away
+      # from a POST use 303 See Other instead.
       def redirect_to(location)
-        response.redirect(location)
+        http_version = request.env['SERVER_PROTOCOL'] || request.env['HTTP_VERSION']
+        status = (http_version == 'HTTP/1.1' && request.request_method != 'GET') ? 303 : 302
+        response.redirect(location, status)
       end
 
       def json(data)
+        response.headers.delete('x-frame-options')
+        response.headers.delete('x-xss-protection')
         response['content-type'] = 'application/json'
         response.write(data.to_json)
+      end
+
+      # Exposed so `Rollout::UI.configure { actor { env[...] } }` /
+      # `actor { session[...] }` blocks keep working when instance_eval'd
+      # against this dispatcher, matching Sinatra's own request-scoped
+      # `env`/`session` helpers.
+      def env
+        request.env
+      end
+
+      def session
+        request.session
       end
 
       def render_view(name)

--- a/lib/rollout/ui/web.rb
+++ b/lib/rollout/ui/web.rb
@@ -1,5 +1,6 @@
-require "sinatra"
-require "sinatra/json"
+require "json"
+require "rack"
+require "slim"
 require "rollout"
 
 require "rollout/ui/version"
@@ -7,86 +8,174 @@ require "rollout/ui/config"
 require "rollout/ui/helpers"
 
 module Rollout::UI
-  class Web < Sinatra::Base
-    set :static, true
-    set :public_folder, File.dirname(__FILE__) + '/public'
+  class Web
+    PUBLIC_PATH = File.expand_path('public', __dir__)
 
-    helpers Helpers
+    NOT_FOUND = ->(env) { [404, { 'content-type' => 'text/plain' }, ['Not Found']] }
 
-    get '/' do
-      @rollout = config.get(:instance)
-      @features = @rollout.features.sort_by(&:downcase)
-      if json_request?
-        json(
-          filtered_features(@rollout, @features).map do |feature|
-            feature_to_hash(@rollout.get(feature))
-          end
-        )
-      else
-        slim :'features/index'
+    def initialize
+      @static = Rack::Static.new(NOT_FOUND, urls: ['/css'], root: PUBLIC_PATH)
+    end
+
+    def call(env)
+      status, headers, body = @static.call(env)
+      return [status, headers, body] unless status == 404
+
+      Dispatcher.new.call(env)
+    end
+
+    # Handles a single request. A fresh instance is created per request (see
+    # Web#call above) so the instance variables set by actions and read by
+    # views (@rollout, @feature, etc) can't leak across concurrent requests.
+    class Dispatcher
+      include Helpers
+
+      VIEWS_PATH = File.expand_path('views', __dir__)
+      TEMPLATE_CACHE = {}
+
+      ROUTES = [
+        [:GET, %r{\A/\z}, :index],
+        [:GET, %r{\A/features/new\z}, :new_feature],
+        [:POST, %r{\A/features/new\z}, :create_feature],
+        [:POST, %r{\A/features/(?<feature_name>[^/]+)/activate-percentage\z}, :activate_percentage],
+        [:POST, %r{\A/features/(?<feature_name>[^/]+)/delete\z}, :delete_feature],
+        [:GET, %r{\A/features/(?<feature_name>[^/]+)\z}, :show],
+        [:POST, %r{\A/features/(?<feature_name>[^/]+)\z}, :update],
+      ].freeze
+
+      attr_reader :request, :response, :params
+
+      def call(env)
+        @request = Rack::Request.new(env)
+        @response = Rack::Response.new
+
+        route = ROUTES.find { |verb, pattern, _| verb == request.request_method.to_sym && pattern.match?(request.path_info) }
+        return not_found unless route
+
+        _, pattern, action = route
+        @params = build_params(pattern.match(request.path_info).named_captures)
+
+        send(action)
+        response.finish
       end
-    end
 
-    get '/features/new' do
-      slim :'features/new'
-    end
+      private
 
-    post '/features/new' do
-      redirect feature_path(params[:name])
-    end
-
-    get '/features/:feature_name' do
-      @rollout = config.get(:instance)
-      @feature = @rollout.get(params[:feature_name])
-
-      if json_request?
-        json(feature_to_hash(@feature))
-      else
-        slim :'features/show'
-      end
-    end
-
-    post '/features/:feature_name' do
-      rollout = config.get(:instance)
-      actor = config.get(:actor, scope: self)
-      feature_data = rollout.get(params[:feature_name]).data
-      if feature_data['updated_at'] && params[:last_updated_at].to_s != feature_data['updated_at'].to_s
-        redirect "#{feature_path(params[:feature_name])}?error=Rollout version outdated. Review changes below and try again."
-      end
-      with_rollout_context(rollout, actor: actor) do
-        rollout.with_feature(params[:feature_name]) do |feature|
-          feature.percentage = params[:percentage].to_f.clamp(0.0, 100.0)
-          feature.groups = (params[:groups] || []).reject(&:empty?).map(&:to_sym)
-          if params[:users]
-            feature.users = params[:users].split(',').map(&:strip).uniq.sort
-          end
-          feature.data.update(description: params[:description])
-          feature.data.update(updated_at: Time.now.to_i)
+      def index
+        @rollout = config.get(:instance)
+        @features = @rollout.features.sort_by(&:downcase)
+        if json_request?
+          json(
+            filtered_features(@rollout, @features).map do |feature|
+              feature_to_hash(@rollout.get(feature))
+            end
+          )
+        else
+          render_view(:'features/index')
         end
       end
 
-      redirect feature_path(params[:feature_name])
-    end
+      def new_feature
+        render_view(:'features/new')
+      end
 
-    post '/features/:feature_name/activate-percentage' do
-      rollout = config.get(:instance)
-      actor = config.get(:actor, scope: self)
+      def create_feature
+        redirect_to feature_path(params[:name])
+      end
 
-      with_rollout_context(rollout, actor: actor) do
-        rollout.with_feature(params[:feature_name]) do |feature|
-          feature.percentage = params[:percentage].to_f.clamp(0.0, 100.0)
-          feature.data.update(updated_at: Time.now.to_i)
+      def show
+        @rollout = config.get(:instance)
+        @feature = @rollout.get(params[:feature_name])
+
+        if json_request?
+          json(feature_to_hash(@feature))
+        else
+          render_view(:'features/show')
         end
       end
 
-      redirect index_path
-    end
+      def update
+        rollout = config.get(:instance)
+        actor = config.get(:actor, scope: self)
+        feature_data = rollout.get(params[:feature_name]).data
+        if feature_data['updated_at'] && params[:last_updated_at].to_s != feature_data['updated_at'].to_s
+          return redirect_to("#{feature_path(params[:feature_name])}?error=Rollout version outdated. Review changes below and try again.")
+        end
 
-    post '/features/:feature_name/delete' do
-      @rollout = config.get(:instance)
-      @rollout.delete(params[:feature_name])
+        with_rollout_context(rollout, actor: actor) do
+          rollout.with_feature(params[:feature_name]) do |feature|
+            feature.percentage = params[:percentage].to_f.clamp(0.0, 100.0)
+            feature.groups = (params[:groups] || []).reject(&:empty?).map(&:to_sym)
+            if params[:users]
+              feature.users = params[:users].split(',').map(&:strip).uniq.sort
+            end
+            feature.data.update(description: params[:description])
+            feature.data.update(updated_at: Time.now.to_i)
+          end
+        end
 
-      redirect index_path
+        redirect_to feature_path(params[:feature_name])
+      end
+
+      def activate_percentage
+        rollout = config.get(:instance)
+        actor = config.get(:actor, scope: self)
+
+        with_rollout_context(rollout, actor: actor) do
+          rollout.with_feature(params[:feature_name]) do |feature|
+            feature.percentage = params[:percentage].to_f.clamp(0.0, 100.0)
+            feature.data.update(updated_at: Time.now.to_i)
+          end
+        end
+
+        redirect_to index_path
+      end
+
+      def delete_feature
+        @rollout = config.get(:instance)
+        @rollout.delete(params[:feature_name])
+
+        redirect_to index_path
+      end
+
+      def not_found
+        response.status = 404
+        response['content-type'] = 'text/plain'
+        response.write('Not Found')
+        response.finish
+      end
+
+      def build_params(route_params)
+        request.params.merge(route_params).each_with_object({}) do |(key, value), hash|
+          hash[key.to_s] = value
+          hash[key.to_sym] = value
+        end
+      end
+
+      def redirect_to(location)
+        response.redirect(location)
+      end
+
+      def json(data)
+        response['content-type'] = 'application/json'
+        response.write(data.to_json)
+      end
+
+      def render_view(name)
+        response['content-type'] = 'text/html;charset=utf-8'
+        response.write(render_template(:layout) { render_template(name) })
+      end
+
+      # Called from within views to render a partial, e.g.
+      # `== slim :"features/partials/event_log", locals: { events: events }`
+      def slim(name, locals: {})
+        render_template(name, locals)
+      end
+
+      def render_template(name, locals = {}, &block)
+        template = (TEMPLATE_CACHE[name] ||= Slim::Template.new(File.join(VIEWS_PATH, "#{name}.slim")))
+        template.render(self, locals, &block)
+      end
     end
   end
 end

--- a/rollout-ui.gemspec
+++ b/rollout-ui.gemspec
@@ -23,8 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'rollout', '~> 2.6'
-  spec.add_dependency 'sinatra', ['>= 2.0', '< 5.0']
-  spec.add_dependency 'sinatra-contrib', ['>= 2.0', '< 5.0']
+  spec.add_dependency 'rack', ['>= 2.2', '< 4.0']
   spec.add_dependency 'slim', ['>= 3.0', '< 6.0']
 
   spec.add_development_dependency 'bundler', '>= 1.17'

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -6,9 +6,7 @@ RSpec.describe 'Web UI' do
   include Rack::Test::Methods
 
   def app
-    Rollout::UI::Web.tap do |app|
-      app.set :host_authorization, skip: true
-    end
+    Rollout::UI::Web.new
   end
 
   it "renders index html" do

--- a/spec/rollout/ui/web_spec.rb
+++ b/spec/rollout/ui/web_spec.rb
@@ -114,4 +114,90 @@ RSpec.describe 'Web UI' do
 
     ROLLOUT.delete(:fake_test_feature_for_rollout_ui_webspec)
   end
+
+  it "decodes percent-encoded feature names from the path" do
+    header 'Accept', 'application/json'
+
+    get '/features/dark%20mode'
+
+    expect(last_response).to be_ok
+    response = JSON.parse(last_response.body)
+    expect(response['name']).to eq('dark mode')
+  end
+
+  it "responds to HEAD requests like the equivalent GET, minus the body" do
+    get '/'
+    get_status = last_response.status
+
+    head '/'
+
+    expect(last_response.status).to eq(get_status)
+    expect(last_response.body).to eq('')
+  end
+
+  it "responds at the exact mount point when Rack::URLMap strips the prefix" do
+    mounted = Rack::URLMap.new('/admin/rollout' => Rollout::UI::Web.new)
+
+    response = Rack::MockRequest.new(mounted).get('/admin/rollout')
+
+    expect(response).to be_ok
+    expect(response.body).to include('Rollout UI')
+  end
+
+  it "sets X-Cascade: pass on 404s so a mounting app can keep matching routes" do
+    get '/this-route-does-not-exist'
+
+    expect(last_response.status).to eq(404)
+    expect(last_response.headers['X-Cascade']).to eq('pass')
+  end
+
+  it "returns 400 for malformed query parameters instead of raising" do
+    get '/?%'
+
+    expect(last_response.status).to eq(400)
+  end
+
+  it "sets baseline security headers on HTML responses but omits framing headers from JSON" do
+    get '/'
+    expect(last_response.headers['X-Content-Type-Options']).to eq('nosniff')
+    expect(last_response.headers['X-Frame-Options']).to eq('SAMEORIGIN')
+    expect(last_response.headers['X-XSS-Protection']).to eq('1; mode=block')
+
+    header 'Accept', 'application/json'
+    get '/'
+    expect(last_response.headers['X-Content-Type-Options']).to eq('nosniff')
+    expect(last_response.headers.key?('X-Frame-Options')).to be false
+    expect(last_response.headers.key?('X-XSS-Protection')).to be false
+  end
+
+  it "updates a feature via POST and redirects (303) to its show page" do
+    post '/features/post_round_trip_feature',
+         { percentage: '42', description: 'a test feature' },
+         'SERVER_PROTOCOL' => 'HTTP/1.1'
+
+    expect(last_response.status).to eq(303)
+    expect(last_response.headers['Location']).to include('/features/post_round_trip_feature')
+
+    feature = ROLLOUT.get(:post_round_trip_feature)
+    expect(feature.percentage).to eq(42.0)
+    expect(feature.data['description']).to eq('a test feature')
+
+    ROLLOUT.delete(:post_round_trip_feature)
+  end
+
+  it "evaluates the configured actor block with request env/session access, matching Sinatra's own helpers" do
+    original_actor_block = Rollout::UI.config.instance_variable_get(:@blocks)[:actor]
+    Rollout::UI.configure { actor { env['HTTP_USER_AGENT'] } }
+
+    header 'User-Agent', 'test-agent'
+    expect do
+      post '/features/actor_env_test_feature/activate-percentage',
+           { percentage: '50' },
+           'SERVER_PROTOCOL' => 'HTTP/1.1'
+    end.not_to raise_error
+    expect(last_response.status).to eq(303)
+
+    ROLLOUT.delete(:actor_env_test_feature)
+    Rollout::UI.config.instance_variable_get(:@blocks)[:actor] = original_actor_block
+  end
 end


### PR DESCRIPTION
## Summary

**What:** 

Removes the `sinatra` and `sinatra-contrib` runtime dependencies. `Rollout::UI::Web` is now a plain Rack app instead of a `Sinatra::Base` subclass — routing, Slim rendering, static asset serving, and redirects are all hand-rolled on top of `Rack::Request`/`Rack::Response` and `Slim::Template` directly.

**Why:** 

This gem only used a handful of Sinatra's routes (6 endpoints) and one sinatra-contrib helper (`sinatra/json`). That's a lot of dependency surface — and its own transitive deps — for functionality this gem can own directly in a couple hundred lines, with no behaviour change for consumers. 

It also removes this from Sinatra's own release cadence: the gemspec was pinned to `< 5.0` because Sinatra 5.0 (which brings the Mustermann/Rack version bump many projects are waiting on) has been stuck behind an unmerged upgrade PR ([sinatra/sinatra#2163](https://github.com/sinatra/sinatra/pull/2163)) for a long time. Dropping the dependency sidesteps that entirely. 

This is also a well-trodden path — [Sidekiq's own web UI](https://github.com/sidekiq/sidekiq/blob/main/lib/sidekiq/web.rb) is built the same way: a plain Rack app with its own small router, rather than depending on Sinatra.

## What changed

- **`lib/rollout/ui/web.rb`** — `Web` is now a small Rack app:
  - Serves `/css/*` via `Rack::Static`, delegates everything else to a `Dispatcher`.
  - A fresh `Dispatcher` instance is created per request (mirrors Sinatra's own per-request instantiation) so instance variables like `@rollout`/`@feature` can't leak across concurrent requests on a threaded server.
  - Routes are matched against an ordered `[verb, regex, action]` list, replacing Sinatra's DSL.
  - Views render via `Slim::Template` directly, with a small template cache and a hand-rolled `slim(name, locals:)` method so partials (e.g. the event log) still work from within views.
  - `sinatra/json`'s `json` helper is replaced with a two-line equivalent (`content-type` + `#to_json`).
- **`lib/rollout/ui/helpers.rb`, `config.rb`, `ui.rb`** — dropped `require "sinatra"`.
- **`rollout-ui.gemspec`** — removed `sinatra`/`sinatra-contrib`; added `rack` as an explicit dependency (previously pulled in transitively via Sinatra).
- **`spec/rollout/ui/web_spec.rb`** — `app` now returns `Rollout::UI::Web.new`; dropped the Sinatra-specific `host_authorization` test setting, which no longer applies.

## Test plan

- [x] `bundle install` resolves with no Sinatra in the dependency tree
- [x] `bundle exec rspec` — full suite passes (8/8)
- [x] Manual smoke test via `bundle exec rackup config.ru`: index (HTML + JSON), static CSS, new/create/show/update/activate/delete feature flows, redirects, and 404s all behave as before

<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 08 12 16" src="https://github.com/user-attachments/assets/56af993f-8bbc-4014-9bcf-74530d0c9c34" />

<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 08 12 26" src="https://github.com/user-attachments/assets/1ecce1cc-35cb-4ad0-82dc-a9a7a57657a7" />

<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 08 12 43" src="https://github.com/user-attachments/assets/78c97235-bde5-4b59-97a5-417c63e334c3" />

<img width="1728" height="1117" alt="Screenshot 2026-07-23 at 08 13 17" src="https://github.com/user-attachments/assets/d5627750-3765-43c5-8c05-f2847c555384" />

<img width="867" height="675" alt="Screenshot 2026-07-23 at 08 14 03" src="https://github.com/user-attachments/assets/67583d3f-649d-451c-bb44-051026183f10" />
